### PR TITLE
Fix the JSON syntax of the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ An example mimebundle:
 
 ```json
 {
-  'application/vnd.jupyter.es6-rich-output': 'a string that will be the src of a script tag, i.e., a url, data url, etc.',
-  'application/vnd.jupyter.datagrid+json': {'data': ['some', 'data', 'in', 'a', 'structure', 'which', 'the', 'js', 'can', 'access']},
-  'text/html': 'fallback rendering of your data',
-  'text/plain': 'fallback rendering of your data'
+    "application/vnd.jupyter.es6-rich-output": "a string that will be the src of a script tag, i.e., a url, data url, etc.",
+    "application/vnd.jupyter.datagrid+json": {
+        "data": ["some", "data", "in", "a", "structure", "which", "the", "js", "can", "access"]
+    },
+    "text/html": "fallback rendering of your data",
+    "text/plain": "fallback rendering of your data"
 }
 ```
 


### PR DESCRIPTION
So the example renders nicely in the README:

![image](https://user-images.githubusercontent.com/591645/198523141-a16a1f93-8f1d-4d3b-a4f7-36b453d8a47b.png)
